### PR TITLE
READMEにDB設計を記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 ### Association
-- has_many :groups
+- belongs_to :group
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -1,24 +1,39 @@
-# README
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false|
+|password|string|null: false|
+|nickname|string|null: false|
+### Association
+- has_many :tweets
+- has_many :groups_users
+- has_many :groups, through: :groups_users
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+|user_id|integer|null: false, foreign_key: true|
+### Association
+- has_many :tweets
+- has_many :groups_users
+- has_many :users, through: :groups_users
 
-Things you may want to cover:
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user
 
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## tweetsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|string|null: false|
+|image|text||
+|user_id|integer|null: false, foreign_key: true|
+### Association
+- has_many :groups
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 |password|string|null: false|
 |nickname|string|null: false|
 ### Association
-- has_many :tweets
+- has_many :messages
 - has_many :groups_users
 - has_many :groups, through: :groups_users
 
@@ -15,7 +15,7 @@
 |group_name|string|null: false|
 |user_id|integer|null: false, foreign_key: true|
 ### Association
-- has_many :tweets
+- has_many :messages
 - has_many :groups_users
 - has_many :users, through: :groups_users
 
@@ -28,7 +28,7 @@
 - belongs_to :group
 - belongs_to :user
 
-## tweetsテーブル
+## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |text|string|null: false|

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
-|user_id|integer|null: false, foreign_key: true|
+|name|string|null: false|
 ### Association
 - has_many :messages
 - has_many :groups_users
@@ -31,9 +30,10 @@
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|string|null: false|
+|text|string||
 |image|text||
 |user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 ### Association
 - has_many :groups
 - belongs_to :user


### PR DESCRIPTION
#What
  chat-space実装前データベースの設計を行う。usersテーブル、groupsテーブル、tweetsテーブルと中間テーブルのgroups_usersテーブル

#Why
　データベースの設計は実装前に必須のため